### PR TITLE
Improve performance by ~10x

### DIFF
--- a/Rake/Helpers/StopListHelper.cs
+++ b/Rake/Helpers/StopListHelper.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+namespace Rake
+{
+    internal static class StopListHelper
+    {
+        public static HashSet<string> ParseFromPath(string? stopWordsPath)
+        {
+            var stopWords = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var line in string.IsNullOrWhiteSpace(stopWordsPath)
+                ? ReadDefaultStopListLine()
+                : File.ReadAllLines(stopWordsPath))
+            {
+                ReadOnlySpan<char> normalizedLine = line.AsSpan().Trim();
+
+                if (normalizedLine.Length == 0 || normalizedLine[0] == '#') continue;
+
+                var splitter = new StringSplitter(normalizedLine, ' ');
+
+                while (splitter.TryGetNext(out var word))
+                {
+                    stopWords.Add(word.ToString());
+                }
+            }
+
+            return stopWords;
+        }
+
+        private static IEnumerable<string> ReadDefaultStopListLine()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var resourceName = "Rake.SmartStoplist.txt";
+
+            using var stream = assembly.GetManifestResourceStream(resourceName);
+            using var reader = new StreamReader(stream);
+
+            string? line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                yield return line;
+            }
+        }
+    }
+}

--- a/Rake/Helpers/StringSplitter.cs
+++ b/Rake/Helpers/StringSplitter.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace Rake
+{
+    internal ref struct StringSplitter
+    {
+        private readonly ReadOnlySpan<char> text;
+        private readonly char seperator;
+
+        private int position;
+
+        public StringSplitter(ReadOnlySpan<char> text, char seperator)
+        {
+            this.text = text;
+            this.seperator = seperator;
+            this.position = 0;
+        }
+
+        public bool TryGetNext(out ReadOnlySpan<char> result)
+        {
+            if (position >= text.Length)
+            {
+                result = default;
+
+                return false;
+            }
+
+            int start = position;
+
+            int commaIndex = text.Slice(position).IndexOf(seperator);
+
+            if (commaIndex > -1)
+            {
+                position += commaIndex + 1;
+
+                result = text.Slice(start, commaIndex);
+            }
+            else
+            {
+                position = text.Length;
+
+                result = text.Slice(start);
+            }
+
+            return true;
+
+        }
+    }
+}

--- a/Rake/Rake.cs
+++ b/Rake/Rake.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 


### PR DESCRIPTION
This PR is focused on improving performance and reducing allocations by:

- Normalizing input in-one shot
- Using spans, where possible, to eliminate allocations
- Simplifying the stop list implementation and eliminating the use of a complex Regex
- Eliminating virtual calls by passing concrete types

On .NETCOREAPP3.1, this shows a roughly 10x performance improvement.